### PR TITLE
Update improvement

### DIFF
--- a/.github/workflows/chocomilk.yml
+++ b/.github/workflows/chocomilk.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Play chocomilk
         uses: open-circle-ltd/chocomilk@master
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
           ANSIBLE_DEPRECATION_WARNINGS: "false"
-          CHOCOLATEY_ITIGO_API_KEY: ${{ secrets.CHOCOLATEY_ITIGO_API_KEY }}
+          CHOCOLATEY_CHOCOWALL_API_KEY: ${{ secrets.CHOCOLATEY_CHOCOWALL_API_KEY }}
           CHOCOLATEY_ORG_API_KEY: ${{ secrets.CHOCOLATEY_ORG_API_KEY }}
           MATTERMOST_API_KEY: ${{ secrets.MATTERMOST_API_KEY }}
           GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ choco install wwphone-cti --params="'/32bit'"
 
 ## Copyright
 
-&copy; 2023, Open Circle AG
+&copy; 2025, Open Circle AG

--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -1,10 +1,10 @@
-$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop';
 $PackageParameters = Get-PackageParameters
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://wwcom.ch/downloads/test/cti_4_2_6.exe' 
-$url64 = 'https://wwcom.ch/downloads/test/cti64_4_2_6.exe'
-$checksum = 'e0fc651ffdf70da83d1cf622d36a7db0ac8adf0326ee4631eb946381035b40ad34bd4f00e701114a646a18e96c4a1dbe1c864c4d016f0e7699a5eb2328979a94'
-$checksum64 = 'a5d950923302b153622dc24721f430c15d013e0a5e20629c4c7cbd6f9c15a387057e46d412e3170184387ffc0a023de5f46e64c7ed092096c8b5fb8ceacee20f'
+$url = 'https://wwcom.ch/downloads/cti_4_2_7.exe' 
+$url64 = 'https://wwcom.ch/downloads/cti64_4_2_7.exe'
+$checksum = 'c5f2238b4e7872c08e0452376189521a44e37dcbf9e0df5f09933285924fa625fed35650fce045dcc989b0b2fcc554514389c543c4a22116f7be4b1326377514'
+$checksum64 = '64fb13603af1ba17b312e17381dcad273d1bf18c2aa303d59b813983f898b7d51136de327a7b6d8d4e75860f5aa3a07e744dc758aa08fac4f68b065e0a9ae1b9'
 
 # Prep 32bit install
 $32bit = $false

--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -1,10 +1,10 @@
 $ErrorActionPreference = 'Stop';
 $PackageParameters = Get-PackageParameters
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://wwcom.ch/downloads/cti_4_1_13.exe' 
-$url64 = 'https://wwcom.ch/downloads/cti64_4_1_13.exe'
-$checksum = 'dc1ed882d08300d0f22cc8743cd1993de9a3be5e9a5e3cb4659064c8d5cad3a781e6097a432741bbe3b3547e1ae0b8495c5584dad39a2d5ea579701758a482c9'
-$checksum64 = '54dd48f03ee0fa9cce67523464f35ec1a9178eb8de23f114dc7589ee517e9f22b219b4594f5d90878f39647dd618dba31dd10a692562527fbc410d50cf917759'
+$url = 'https://wwcom.ch/downloads/test/cti_4_2_6.exe' 
+$url64 = 'https://wwcom.ch/downloads/test/cti64_4_2_6.exe'
+$checksum = 'e0fc651ffdf70da83d1cf622d36a7db0ac8adf0326ee4631eb946381035b40ad34bd4f00e701114a646a18e96c4a1dbe1c864c4d016f0e7699a5eb2328979a94'
+$checksum64 = 'a5d950923302b153622dc24721f430c15d013e0a5e20629c4c7cbd6f9c15a387057e46d412e3170184387ffc0a023de5f46e64c7ed092096c8b5fb8ceacee20f'
 
 # Prep 32bit install
 $32bit = $false
@@ -23,7 +23,7 @@ $packageArgs64 = @{
   softwareName  = 'cti*'
   checksum      = $checksum64
   checksumType  = 'sha512'
-  silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' + 
+  silentArgs    = '/MOVEEXISTING /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOCLOSEAPPLICATIONS /SP-' + 
   " /Log=`"$env:TEMP\$env:ChocolateyPackageName.$env:ChocolateyPackageVersion.Install.log`""
 }
 
@@ -36,7 +36,7 @@ $packageArgs32 = @{
   softwareName  = 'cti*'
   checksum      = $checksum
   checksumType  = 'sha512'
-  silentArgs   = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' + 
+  silentArgs    = '/MOVEEXISTING /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOCLOSEAPPLICATIONS /SP-' + 
   " /Log=`"$env:TEMP\$env:ChocolateyPackageName.$env:ChocolateyPackageVersion.Install.log`""
 }
 

--- a/package/wwphone-cti.nuspec
+++ b/package/wwphone-cti.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wwphone-cti</id>
-    <version>4.1.13</version>
+    <version>4.2.6</version>
     <packageSourceUrl>https://github.com/open-circle-ltd/chocolatey.wwphone.cti</packageSourceUrl>
     <owners>Benaiah Matthew Catherasoo, Open Circle AG</owners>
     <title>wwphone CTI-Client</title>

--- a/package/wwphone-cti.nuspec
+++ b/package/wwphone-cti.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wwphone-cti</id>
-    <version>4.2.6</version>
+    <version>4.2.7</version>
     <packageSourceUrl>https://github.com/open-circle-ltd/chocolatey.wwphone.cti</packageSourceUrl>
     <owners>Benaiah Matthew Catherasoo, Open Circle AG</owners>
     <title>wwphone CTI-Client</title>


### PR DESCRIPTION
- Introducing new parameters: `/MOVEEXISTING`, `/NOCLOSEAPPLICATIONS`
- Allow in-place upgrades
- Upgrade actions/checkout to v4
- update version to 4.2.7

>Mit /MOVEEXISTING /VERYSILENT /NOCLOSEAPPLICATIONS
Werden sämtliche Files statt überschrieben umbenannt und Windows angewiesen, diese temporären Files beim nächsten Systemstart zu löschen. Danach (nach dem Umbenennen, also nicht erst nach dem Löschen) werden die neuen Versionen der Files installiert. So sollten Nutzer, welche die Applikation neu starten, auch ohne Reboot des Systems die aktuelle Version erhalten.